### PR TITLE
Fixed typo in Quaternion.export()

### DIFF
--- a/skinematics/quat.py
+++ b/skinematics/quat.py
@@ -256,7 +256,7 @@ class Quaternion():
         if to.lower() == 'vector' :
             return self.values[:,1:]
 
-        if to.lower == 'euler':
+        if to.lower() == 'euler':
             Euler = np.zeros((len(self),3))
             rm = self.export()
             if rm.shape == (3,3):


### PR DESCRIPTION
A typo in the conditional checking if export format is euler caused
export('euler') to always return None. Now it returns the euler angles, as
expected.