### PR TITLE
fixed scipy has no attribute 'constants'

### DIFF
--- a/skinematics/imus.py
+++ b/skinematics/imus.py
@@ -16,6 +16,7 @@ Date: Oct-2016
 
 import numpy as np
 import scipy as sp
+import sp.constants
 from scipy.integrate import cumtrapz
 import matplotlib.pyplot as plt
 import pandas as pd 


### PR DESCRIPTION
In my code 

```
...
imu=skin.imus.IMUS(inData=indata)
imu.calc_position([0,0,0])
```

An error `AttributeError: module has no attribute sp.constants.g` is thrown

This direct import fixes it.