### PR TITLE
Make automatic module import failsafe

### DIFF
--- a/skinematics/__init__.py
+++ b/skinematics/__init__.py
@@ -23,7 +23,9 @@ __license__ = "BSD 2-Clause License"
 __version__ = "0.8.3"
 
 __all__ = ['imus', 'markers', 'misc', 'quat', 'rotmat', 'vector', 'view', 'sensors']
-#__all__ = []
 
 for _m in __all__:
-    importlib.import_module('.'+_m, package='skinematics')
+    try:
+        importlib.import_module('.'+_m, package='skinematics')
+    except:
+        print(f"Failed to automatically import {_m}.")

--- a/skinematics/__init__.py
+++ b/skinematics/__init__.py
@@ -22,10 +22,19 @@ __author__ = "Thomas Haslwanter <thomas.haslwanter@fh-linz.at"
 __license__ = "BSD 2-Clause License"
 __version__ = "0.8.3"
 
-__all__ = ['imus', 'markers', 'misc', 'quat', 'rotmat', 'vector', 'view', 'sensors']
 
-for _m in __all__:
+required_imports = ['markers', 'quat', 'rotmat', 'vector', 'sensors']
+optional_imports = ['imus', 'misc', 'view']
+
+__all__ = []
+for _m in required_imports:
+    importlib.import_module('.'+_m, package='skinematics')
+    __all__.append(_m)
+
+for _m in optional_imports:
     try:
         importlib.import_module('.'+_m, package='skinematics')
-    except:
-        print(f"Failed to automatically import {_m}.")
+        __all__.append(_m)
+    except ModuleNotFoundError:
+        print("Failed to import optional module {}. Install optional dependencies".format(_m))
+


### PR DESCRIPTION
The current version of the codebase can not be used in a headless setup, i.e. without access to tikinter for displaying UIs, since `__init__.py` automatically imports all modules, including the ones used for plotting.

I would propose to make the automatic import failsave by catching and displaying import errors.

## Steps to repro

Clone repository; install dependencies specified in `setup.py` and execute from root, on a setup without GUI access (i.e., without an X11 server running)

``` bash
python3 -c "import skinematics"
```

## Expected behavior

The parts not requiring a GUI should be imported without any errors.

## Actual behavior

We get this error in a headless setup

``` bash
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/steffen/scikit-kinematics/skinematics/__init__.py", line 29, in <module>
    importlib.import_module('.'+_m, package='skinematics')
  File "/usr/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/home/steffen/scikit-kinematics/skinematics/imus.py", line 40, in <module>
    import quat, vector, misc, rotmat
  File "/home/steffen/scikit-kinematics/skinematics/misc.py", line 25, in <module>
    import tkinter 
ModuleNotFoundError: No module named 'tkinter'
```

It is possible to install the required packages e.g. in Ubuntu; then the error fails on the `tikinter` import, e.g. with an OpenGL error message.

## Proposed Fix

Partition the modules into required and optional modules. Catch the `ModuleImportError` for all optional modules. This makes it possible to run the same code base on both headless and X11 based systems.

Applying the fix yields this behavior:
``` bash
python3 -c "import skinematics"
Failed to import optional module imus. Install optional dependencies
Failed to import optional module misc. Install optional dependencies
Failed to import optional module view. Install optional dependencies
```

I am happy for suggestions on also adapting `setup.py` as part of this PR.
