### PR TITLE
use float instead of np.float

### DIFF
--- a/src/skinematics/imus.py
+++ b/src/skinematics/imus.py
@@ -304,7 +304,7 @@ class IMU_Base(metaclass=abc.ABCMeta):
             self._checkRequirements()
 
             # Initialize object
-            AHRS = Mahony(rate=np.float(self.rate), Kp=0.4)  # previously: Kp=0.5
+            AHRS = Mahony(rate=float(self.rate), Kp=0.4)  # previously: Kp=0.5
             quaternion = np.zeros((self.totalSamples, 4))
 
             # The "Update"-function uses angular velocity in radian/s, and only
@@ -343,9 +343,9 @@ class IMU_Base(metaclass=abc.ABCMeta):
 
         for ii in range(accReSpace.shape[1]):
             vel[:,ii] = cumtrapz(accReSpace[:,ii],
-                                 dx=1./np.float(self.rate), initial=0)
+                                 dx=1./float(self.rate), initial=0)
             pos[:,ii] = cumtrapz(vel[:,ii],
-                        dx=1./np.float(self.rate), initial=initialPosition[ii])
+                        dx=1./float(self.rate), initial=initialPosition[ii])
 
         self.vel = vel
         self.pos = pos
@@ -362,7 +362,7 @@ class IMU_Base(metaclass=abc.ABCMeta):
         '''Complete the information properties of that IMU'''
 
         self.totalSamples = len(self.omega)
-        self.duration = np.float(self.totalSamples)/self.rate # [sec]
+        self.duration = float(self.totalSamples)/self.rate # [sec]
         self.dataType = str(self.omega.dtype)
 
 
@@ -735,7 +735,7 @@ class Mahony:
         if self.Ki > 0:
             self._eInt += e * self.SamplePeriod  
         else:
-            self._eInt = np.array([0, 0, 0], dtype=np.float)
+            self._eInt = np.array([0, 0, 0], dtype=float)
 
         # Apply feedback terms
         Gyroscope += self.Kp * e + self.Ki * self._eInt;            

--- a/src/skinematics/sensors/polulu.py
+++ b/src/skinematics/sensors/polulu.py
@@ -57,7 +57,7 @@ class Polulu(IMU_Base):
             data.columns = ['acc_x', 'acc_y', 'acc_z', 'gyr_x', 'gyr_y', 'gyr_z', 'mag_x', 'mag_y', 'mag_z', 'taccgyr', 'tmag']
             
             # interpolate with a manually set rate. Note that this sensor acquires exactly 25 seconds!
-            dt = 1/np.float(rate)
+            dt = 1/float(rate)
             t_lin = np.arange(0, 25, dt)
     
             data_interp = pd.DataFrame()

--- a/src/skinematics/sensors/xio_ngimu.py
+++ b/src/skinematics/sensors/xio_ngimu.py
@@ -66,7 +66,7 @@ def read_ratefile(reg_file):
         if line.find('rate') > 0:
             # e.g.: "/rate/quaternion, 50f"
             param_full, val_txt = line.split()
-            value = np.float(val_txt[:-1])  # skip the "f"
+            value = float(val_txt[:-1])  # skip the "f"
             param = param_full.split('/')[2][:-1]
             if value > 0:
                 rates[param] = value

--- a/src/skinematics/sensors/xsens.py
+++ b/src/skinematics/sensors/xsens.py
@@ -46,7 +46,7 @@ class XSens(IMU_Base):
             fh = open(in_file)
             fh.readline()
             line = fh.readline()
-            rate = np.float(line.split(':')[1].split('H')[0])
+            rate = float(line.split(':')[1].split('H')[0])
             fh.close()
     
         except FileNotFoundError:


### PR DESCRIPTION
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

With NumPy 1.20.0, np.float has been deprecated. This PR fixes all issues regarding np.float by replacing all instances of it with the inbuilt float function. All functionality should stay the same